### PR TITLE
First cut at diff functionality

### DIFF
--- a/lib/Synchronise/Diff.hs
+++ b/lib/Synchronise/Diff.hs
@@ -9,48 +9,146 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 -- | Description: Diff and patch /Synchronise/ documents.
 module Synchronise.Diff
-     ( MergePolicy(..)
-     , diff
+     ( -- * Operations
+       diff
+     , patch
      , mergePatches
 
-       -- * Re-exports
-     , Operation(..)
-     , Patch(..)
+       -- * Merge policies
+     , MergePolicy(..)
+     , acceptAll
+     , rejectAll
+     , ignoreConflicts
+     , trustOnlySource
 
+       -- * Representing patches
+     , Patch(..)
+     , patchLabel
+     , patchDiff
+     , RejectedOp(..)
+     , rejectedLabel
+     , rejectedOperation
      ) where
 
 import Control.Lens hiding ((.=))
-import Data.Aeson.Diff (Operation, Patch)
 import qualified Data.Aeson.Diff as D
 import Data.Monoid
 
 import Synchronise.Document
+import Synchronise.Identifier
 
+-- | A /synchronised/ 'Patch' is an @aeson-diff@ patch together with a label.
+data Patch l = Patch
+    { _patchLabel :: l
+    , _patchDiff  :: D.Patch
+    }
+  deriving (Eq, Show)
+makeLenses ''Patch
+
+-- | An @aeson-diff@ patch operation which was excluded be a 'MergePolicy'.
+data RejectedOp l = RejectedOp
+    { _rejectedLabel     :: l
+    , _rejectedOperation :: D.Operation
+    }
+  deriving (Eq, Show)
+makeLenses ''RejectedOp
+
+-- | Describes the way we merge diffs.
 data MergePolicy l = MergePolicy
     { extractLabel :: Document -> l
-    , mergePatchs  :: Patch -> Patch -> Patch }
+    , mergePatch   :: Patch l -> Patch l -> (Patch l, [RejectedOp l])
+    }
 
+-- | Accept all changes, and let them stomp all over each other.
+acceptAll :: MergePolicy ()
+acceptAll = MergePolicy{..}
+  where
+    extractLabel = const ()
+    mergePatch p1 p2 =
+        let p = Patch () $ (p1 ^. patchDiff) <> (p2 ^. patchDiff)
+            r = []
+        in (p,r)
+
+-- | Reject all changes.
+rejectAll :: MergePolicy ()
+rejectAll = MergePolicy{..}
+  where
+    extractLabel = const ()
+    mergePatch p1 p2 =
+        let p = Patch () mempty
+            r1 = reject p1
+            r2 = reject p2
+        in (p, r1 <> r2)
+
+-- | Trust only patches from a particular 'DataSource', discarding all other
+-- changes.
+trustOnlySource :: SourceName -> MergePolicy SourceName
+trustOnlySource name = MergePolicy {..}
+  where
+    extractLabel d = d ^. documentSource
+    mergePatch p1 p2
+        | name == (p2 ^. patchLabel) = (p2, reject p1)
+        | name == (p1 ^. patchLabel) = (p1, reject p2)
+        | otherwise =
+            let
+                p = Patch name mempty
+                r = reject p1 <> reject p2
+            in (p,r)
+
+-- | Merge diffs, ignoring all changes which conflict.
+--
+-- TODO(thsutton) Implement logic here.
+ignoreConflicts :: MergePolicy ()
+ignoreConflicts = MergePolicy{..}
+  where
+    extractLabel = const ()
+    mergePatch p1 p2 =
+        let p = Patch () mempty
+            r = reject p1 <> reject p2
+        in (p,r)
+
+-- | Use a 'MergePolicy' to compare two versions of a document and extract a
+-- 'Patch' describing changes.
 diff
     :: MergePolicy l
     -> Document
     -> Document
-    -> Patch
+    -> Patch l
 diff MergePolicy{..} d1 d2 =
     let j1 = d1 ^. documentContent
         j2 = d2 ^. documentContent
-    in  D.diff j1 j2
+        l = extractLabel d2
+        d = D.diff j1 j2
+    in Patch l d
+
+-- | Use a 'MergePolicy' to apply a 'Patch' to a 'Document'.
+patch
+    :: MergePolicy l
+    -> Patch l
+    -> Document
+    -> Document
+patch MergePolicy{} p d = d & documentContent %~ D.patch (p ^. patchDiff)
 
 -- | Combine two 'Patch'es according to the rules of a 'MergePolicy'.
 --
 -- This allows case-specific criteria to be used in resolving ambiguities which
 -- might arise when resolving conflicts between patches.
+--
+-- TODO(thsutton) Rename the record field and delete this?
 mergePatches
     :: Monoid l
     => MergePolicy l
-    -> Patch
-    -> Patch
-    -> (Patch, (Patch, Patch))
-mergePatches MergePolicy{..} p1 p2 = (mempty, (p1, p2))
+    -> Patch l
+    -> Patch l
+    -> (Patch l, [RejectedOp l])
+mergePatches MergePolicy{..} = mergePatch
+
+-- * Utility
+
+-- | Convert all the 'D.Operation's in a 'D.Patch' into 'RejectedOp's.
+reject :: Patch l -> [RejectedOp l]
+reject p = fmap (RejectedOp (p ^. patchLabel)) . D.patchOperations $ p ^. patchDiff

--- a/lib/Synchronise/Document.hs
+++ b/lib/Synchronise/Document.hs
@@ -31,7 +31,6 @@ import Data.Monoid
 
 import Synchronise.Identifier
 
-
 -- | A JSON 'Value' from a particular 'Entity'.
 data Document = Document
     { _documentEntity  :: EntityName -- ^ Type of data.

--- a/lib/Synchronise/Network/Protocol.hs
+++ b/lib/Synchronise/Network/Protocol.hs
@@ -19,7 +19,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.Typeable
 
-import Synchronise.Diff
 import Synchronise.Document
 import Synchronise.Identifier
 import Synchronise.Store
@@ -89,7 +88,7 @@ data RequestConflicted = RequestConflicted
 
 data ResponseConflictedItem = ResponseConflictedItem
     { _conflictDocument :: Document
-    , _conflictPatch    :: Patch
+    , _conflictPatch    :: Diff.Patch
     , _conflictDiffID   :: DiffID
     , _conflictOps      :: [(OpID, BS.ByteString)]
     } deriving (Eq, Show)
@@ -206,7 +205,7 @@ instance Binary SourceName where
     put (SourceName n) = put n
     get = SourceName <$> get
 
-instance Binary Patch where
+instance Binary Diff.Patch where
     put = put . Aeson.encode
     get = getJSON
 

--- a/lib/Synchronise/Store/Base.hs
+++ b/lib/Synchronise/Store/Base.hs
@@ -30,13 +30,13 @@ import Control.Applicative
 import Control.Lens hiding ((.=))
 import Control.Monad
 import Data.Aeson
+import qualified Data.Aeson.Diff as D
 import Data.ByteString (ByteString)
 import Data.Monoid
 
 import Synchronise.Diff
 import Synchronise.Document
 import Synchronise.Identifier
-
 
 type DiffID  = Int
 type OpID    = Int
@@ -52,15 +52,15 @@ makeLenses ''ConflictResp
 data DiffResp = DiffResp
   { _diffEntity    :: ByteString
   , _diffKey       :: Int
-  , _diffPatch     :: Patch
-  , _diffConflicts :: [Patch]
+  , _diffPatch     :: D.Patch
+  , _diffConflicts :: [D.Operation]
   }
 makeLenses ''DiffResp
 
 data OpResp = OpResp
   { _opDiffID :: DiffID
   , _opID     :: OpID
-  , _ops      :: Operation
+  , _ops      :: D.Operation
   }
 makeLenses ''OpResp
 
@@ -128,7 +128,7 @@ class Store store where
 
   -- | Record the success 'Diff' and a list of failed 'Diff's associated with a
   --   processed 'InternalKey'.
-  recordDiffs         :: store -> InternalKey -> (Patch, [Patch]) -> IO DiffID
+  recordDiffs         :: store -> InternalKey -> (D.Patch, [D.Patch]) -> IO DiffID
 
   -- | Record that the conflicts in a 'Diff' are resolved.
   resolveDiffs        :: store -> Int -> IO ()
@@ -179,7 +179,7 @@ data WorkItem
     -- | A document was changed; process the update.
     = WorkNotify ForeignKey
     -- | A patch was submitted by a human; apply it.
-    | WorkApplyPatch Int Patch
+    | WorkApplyPatch Int D.Patch
     deriving (Show, Eq)
 
 instance ToJSON WorkItem where

--- a/lib/Synchronise/Store/Memory.hs
+++ b/lib/Synchronise/Store/Memory.hs
@@ -8,19 +8,17 @@ module Synchronise.Store.Memory
      , Mem
      ) where
 
-
 import Control.Applicative
 import Control.Lens
+import qualified Data.Aeson.Diff as D
 import Data.IORef
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Monoid
 
-import Synchronise.Diff
 import Synchronise.Document
 import Synchronise.Identifier
 import Synchronise.Store.Base
-
 
 -- | An acid-state like in-memory store.
 type Mem = IORef MemStore
@@ -30,7 +28,7 @@ data MemStore = MemStore
     , _memItoF    :: Map InternalKey (Map SourceName ForeignID)
     , _memFtoI    :: Map ForeignKey InternalID
     , _memInits   :: Map InternalKey Document
-    , _memDiffs   :: Map InternalKey [(Patch, [Patch])]
+    , _memDiffs   :: Map InternalKey [(D.Patch, [D.Patch])]
     }
 makeLenses ''MemStore
 


### PR DESCRIPTION
I'm not sure if I like the whole "S.Diff uses it's own types, everyone else uses aeson-diff types" thing that I've done here.

Also: the `ignoreConflicts` policy implementation is wrong.